### PR TITLE
Use name in import_roles to fix ERROR:

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,15 +21,18 @@
       - name: "{{ database_name }}"
         owner: "{{ odoo_user }}"
 
-- import_role: coopdevs.certbot_nginx
+- import_role:
+    name: coopdevs.certbot_nginx
   vars:
     domain_name: "{{ inventory_hostname }}"
     letsencrypt_email: "{{ certificate_authority_email }}"
   when: not development_environment
 
-- import_role: jdauphant.nginx
+- import_role:
+    name: jdauphant.nginx
   when: not development_environment
 
-- import_role: coopdevs.odoo-role
+- import_role:
+    name: coopdevs.odoo-role
   vars:
     odoo_db_admin_password: "{{ odoo_admin_password }}"


### PR DESCRIPTION
To fix this error, we need call the `include_role` with name field.

```
➜ ansible-playbook playbooks/provision.yml --limit=dev -vvvvvv
ansible-playbook 2.5.0
  config file =
  /home/daniel/dev/coopdevs/odoo/odoo-coopdevs-treball-provisioning/ansible.cfg
    configured module search path =
    [u'/home/daniel/.ansible/plugins/modules',
    u'/usr/share/ansible/plugins/modules']
      ansible python module location =
      /usr/local/lib/python2.7/dist-packages/ansible
        executable location = /usr/local/bin/ansible-playbook
          python version = 2.7.12 (default, Dec  4 2017, 14:50:18) [GCC
          5.4.0 20160609]
          Using
          /home/daniel/dev/coopdevs/odoo/odoo-coopdevs-treball-provisioning/ansible.cfg
          as config file
          setting up inventory plugins
          Parsed
          /home/daniel/dev/coopdevs/odoo/odoo-coopdevs-treball-provisioning/inventory/hosts
          inventory source with ini plugin
          [DEPRECATION WARNING]: The use of 'static' has been
          deprecated. Use 'import_tasks' for static inclusion, or
          'include_tasks'
          for dynamic inclusion. This feature will be removed in a
          future release. Deprecation warnings can be disabled by
          setting
          deprecation_warnings=False in ansible.cfg.
          ERROR! 'name' is a required field for include_role.
```